### PR TITLE
ci: fix GoReleaser configuration version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: athenaeum
 before:
   hooks:


### PR DESCRIPTION
## Summary
- Update GoReleaser configuration to use version 2 format as required by current GoReleaser releases
- Resolves the release workflow failure with "only configurations files on version 2 are supported, yours is version 0"

## Test plan
- [x] Run tidy task to ensure code quality
- [ ] Verify GitHub workflow passes after merge