### PR TITLE
ci: add v2 branch to PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,7 @@ name: PR Build
 
 on:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "v2"]
 
 jobs:
   lint-title:


### PR DESCRIPTION
## Summary
- Add v2 branch to PR workflow triggers so that pull requests targeting v2 branch run the same tests and linting as main branch

## Test plan
- [x] Verify workflow configuration is valid YAML
- [ ] Test by creating a PR targeting v2 branch to confirm workflow runs