### PR TITLE
refactor: convert store methods to package-level functions

### DIFF
--- a/internal/audiobook/service.go
+++ b/internal/audiobook/service.go
@@ -41,7 +41,7 @@ func (s *Service) WithFilters(filters []Filter) *Service {
 
 func (s *Service) UpdateAudiobooks(ctx context.Context) error {
 	s.logger.Infoln("Updating audiobooks")
-	existingAudiobooks, err := s.store.GetAll(ctx)
+	existingAudiobooks, err := s.store.GetAll()
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (s *Service) UpdateAudiobooks(ctx context.Context) error {
 	}
 
 	if changed {
-		err = s.store.StoreAll(ctx, audiobooksFromScan)
+		err = s.store.StoreAll(audiobooksFromScan)
 		if err != nil {
 			return err
 		}
@@ -72,32 +72,32 @@ func (s *Service) UpdateAudiobooks(ctx context.Context) error {
 
 func (s *Service) GetAllAudiobooks(ctx context.Context) ([]audiobooks.Audiobook, error) {
 	if len(s.filtersForAll) > 0 {
-		return s.store.Get(ctx, AndFilter(s.filtersForAll...))
+		return s.store.Get(AndFilter(s.filtersForAll...))
 	} else {
-		return s.store.GetAll(ctx)
+		return s.store.GetAll()
 	}
 }
 
 func (s *Service) IsReady(ctx context.Context) bool {
-	return s.store.IsReady(ctx)
+	return s.store.IsReady()
 }
 
 func (s *Service) GetAudiobooksByAuthor(ctx context.Context, name string) ([]audiobooks.Audiobook, error) {
-	return s.store.Get(ctx, AuthorFilter(name))
+	return s.store.Get(AuthorFilter(name))
 }
 
 func (s *Service) GetAudiobooksByGenre(ctx context.Context, genre audiobooks.Genre) ([]audiobooks.Audiobook, error) {
-	return s.store.Get(ctx, GenreFilter(genre))
+	return s.store.Get(GenreFilter(genre))
 }
 
 func (s *Service) GetAudiobooksByNarrator(ctx context.Context, name string) ([]audiobooks.Audiobook, error) {
-	return s.store.Get(ctx, NarratorFilter(name))
+	return s.store.Get(NarratorFilter(name))
 }
 
 func (s *Service) GetAudiobooksByTag(ctx context.Context, tag string) ([]audiobooks.Audiobook, error) {
-	return s.store.Get(ctx, TagFilter(tag))
+	return s.store.Get(TagFilter(tag))
 }
 
 func (s *Service) GetAudiobooksBy(ctx context.Context, filter func(*audiobooks.Audiobook) bool) ([]audiobooks.Audiobook, error) {
-	return s.store.Get(ctx, filter)
+	return s.store.Get(filter)
 }

--- a/internal/audiobook/service_test.go
+++ b/internal/audiobook/service_test.go
@@ -25,7 +25,7 @@ func setupServiceTest(t *testing.T) *Service {
 	store, err := NewStore(dbRoot, logger)
 	require.NoError(t, err)
 
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
 	return NewService(store, testMediaRoot, logger)
@@ -92,7 +92,7 @@ func TestService_GetAllAudiobooks_WithoutFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store test books
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
 	service := NewService(store, testMediaRoot, logger)
@@ -109,7 +109,7 @@ func TestService_GetAllAudiobooks_WithFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store test books
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
 	// Create service with filter that excludes SciFi
@@ -165,7 +165,7 @@ func TestService_GetAudiobooksBy_CustomFilter(t *testing.T) {
 	store, err := NewStore(dbRoot, logger)
 	require.NoError(t, err)
 
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
 	service := NewService(store, testMediaRoot, logger)
@@ -242,7 +242,7 @@ func TestService_UpdateAudiobooks_WithChangesAndNotifiers(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store some initial books
-	err = store.StoreAll(context.TODO(), []audiobooks.Audiobook{testbooks.Audiobooks[0]})
+	err = store.StoreAll([]audiobooks.Audiobook{testbooks.Audiobooks[0]})
 	require.NoError(t, err)
 
 	updatedThirdParty = false
@@ -265,7 +265,7 @@ func TestService_UpdateAudiobooks_NoChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store all test books first
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
 	updatedThirdParty = false
@@ -288,7 +288,7 @@ func TestService_UpdateAudiobooks_NotifierError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store some initial books
-	err = store.StoreAll(context.TODO(), []audiobooks.Audiobook{testbooks.Audiobooks[0]})
+	err = store.StoreAll([]audiobooks.Audiobook{testbooks.Audiobooks[0]})
 	require.NoError(t, err)
 
 	// Create a notifier that will return an error

--- a/internal/audiobook/store_test.go
+++ b/internal/audiobook/store_test.go
@@ -1,7 +1,6 @@
 package audiobook_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,10 +36,10 @@ func TestStore_StoreAll(t *testing.T) {
 	dbFile := filepath.Join(dbRoot, "audiobooks.db")
 	assert.FileExists(t, dbFile)
 
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	assert.NoError(t, err)
 
-	retrievedBooks, err := store.GetAll(context.TODO())
+	retrievedBooks, err := store.GetAll()
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, testbooks.Audiobooks, retrievedBooks)
 }
@@ -51,10 +50,10 @@ func TestStore_GetAll(t *testing.T) {
 	store, err := audiobook.NewStore(dbRoot, logger)
 	require.NoError(t, err)
 
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
-	retrievedBooks, err := store.GetAll(context.TODO())
+	retrievedBooks, err := store.GetAll()
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, testbooks.Audiobooks, retrievedBooks)
 }
@@ -65,10 +64,10 @@ func TestStore_Get(t *testing.T) {
 	store, err := audiobook.NewStore(dbRoot, logger)
 	require.NoError(t, err)
 
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
-	retrievedBooks, err := store.Get(context.TODO(), func(a *audiobooks.Audiobook) bool {
+	retrievedBooks, err := store.Get(func(a *audiobooks.Audiobook) bool {
 		for _, v := range a.Authors {
 			if v == "Amal El-Mohtar" {
 				return true
@@ -87,7 +86,7 @@ func TestStore_GetAll_WhenEmpty(t *testing.T) {
 	store, err := audiobook.NewStore(dbRoot, logger)
 	require.NoError(t, err)
 
-	retrievedBooks, err := store.GetAll(context.TODO())
+	retrievedBooks, err := store.GetAll()
 	assert.NoError(t, err)
 	assert.Empty(t, retrievedBooks)
 }
@@ -98,7 +97,7 @@ func TestStore_IsReady(t *testing.T) {
 	store, err := audiobook.NewStore(dbRoot, logger)
 	require.NoError(t, err)
 
-	ready := store.IsReady(context.TODO())
+	ready := store.IsReady()
 	assert.True(t, ready)
 }
 
@@ -108,11 +107,11 @@ func TestStore_GetWithFilter(t *testing.T) {
 	store, err := audiobook.NewStore(dbRoot, logger)
 	require.NoError(t, err)
 
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
 	// Test filtering by genre
-	sciFiBooks, err := store.Get(context.TODO(), func(a *audiobooks.Audiobook) bool {
+	sciFiBooks, err := store.Get(func(a *audiobooks.Audiobook) bool {
 		for _, genre := range a.Genres {
 			if genre == audiobooks.SciFi {
 				return true
@@ -132,16 +131,16 @@ func TestStore_StoreAll_OverwritesExisting(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store initial books
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
 	// Store only one book (should overwrite all)
 	singleBook := []audiobooks.Audiobook{testbooks.Audiobooks[0]}
-	err = store.StoreAll(context.TODO(), singleBook)
+	err = store.StoreAll(singleBook)
 	require.NoError(t, err)
 
 	// Should only have one book now
-	retrievedBooks, err := store.GetAll(context.TODO())
+	retrievedBooks, err := store.GetAll()
 	assert.NoError(t, err)
 	assert.Len(t, retrievedBooks, 1)
 	assert.Equal(t, testbooks.Audiobooks[0], retrievedBooks[0])
@@ -167,11 +166,11 @@ func TestStore_StoreAll_EmptyList(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store empty list
-	err = store.StoreAll(context.TODO(), []audiobooks.Audiobook{})
+	err = store.StoreAll([]audiobooks.Audiobook{})
 	assert.NoError(t, err)
 
 	// Should have no books
-	retrievedBooks, err := store.GetAll(context.TODO())
+	retrievedBooks, err := store.GetAll()
 	assert.NoError(t, err)
 	assert.Empty(t, retrievedBooks)
 }
@@ -182,11 +181,11 @@ func TestStore_Get_NoMatches(t *testing.T) {
 	store, err := audiobook.NewStore(dbRoot, logger)
 	require.NoError(t, err)
 
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
 	// Filter that matches nothing
-	retrievedBooks, err := store.Get(context.TODO(), func(a *audiobooks.Audiobook) bool {
+	retrievedBooks, err := store.Get(func(a *audiobooks.Audiobook) bool {
 		return false // Never matches
 	})
 	assert.NoError(t, err)
@@ -199,11 +198,11 @@ func TestStore_Get_AllMatch(t *testing.T) {
 	store, err := audiobook.NewStore(dbRoot, logger)
 	require.NoError(t, err)
 
-	err = store.StoreAll(context.TODO(), testbooks.Audiobooks)
+	err = store.StoreAll(testbooks.Audiobooks)
 	require.NoError(t, err)
 
 	// Filter that matches everything
-	retrievedBooks, err := store.Get(context.TODO(), func(a *audiobooks.Audiobook) bool {
+	retrievedBooks, err := store.Get(func(a *audiobooks.Audiobook) bool {
 		return true // Always matches
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
Complete Phase 1.2 of the V2 refactor by converting audiobook store methods to package-level functions and removing unnecessary context parameters.

## Changes Made
- **Convert Store struct methods to package-level functions**: `StoreAll`, `GetAll`, `Get`, `IsReady` are now standalone functions
- **Remove context parameters**: Context removed from store operations since BoltDB is synchronous
- **Add convenience methods**: Store struct retains methods that call the package-level functions for backward compatibility
- **Update all tests**: All test calls updated to use new signatures
- **Clean up code**: Remove unused `getDBPath` method and fix linting issues

## Architecture Improvements
- Store operations now follow functional approach as specified in V2 refactor
- Eliminates unnecessary abstraction while maintaining clean API
- Functions accept DB connection parameters directly instead of using struct state
- Context parameters removed where not needed (BoltDB operations are synchronous)

## Test Plan
- [x] All existing tests pass with new signatures
- [x] Store initialization and operations work correctly
- [x] Code passes all linting and formatting checks
- [x] Functional and struct-based APIs both work

Closes #98

Part of the V2 refactor (#85) - Phase 1.2: Simplify Audiobook Store