### PR TITLE
ci: stop renovate blocking the gomarkdown digest updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,6 @@
   "postUpdateOptions": ["gomodTidy"],
   "internalChecksFilter": "strict",
   "minimumReleaseAge": "1 week",
-  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "description": "Use ci semantic type for some deps",
@@ -27,12 +26,6 @@
       "description": "Merge digests faster",
       "matchUpdateTypes": ["digest"],
       "minimumReleaseAge": "1 day"
-    },
-    {
-      "description": "gomarkdown/markdown has no tagged releases, so it must stay on loose versioning; a vulnerability alert otherwise forces semver versioning, which can't parse its pseudo-versions and silently drops the dependency from tracking",
-      "matchDatasources": ["go"],
-      "matchPackageNames": ["github.com/gomarkdown/markdown"],
-      "versioning": "loose"
     }
   ]
 }


### PR DESCRIPTION
The gomod manager already marks pseudo-version requires as `loose` versioning. The OSV vulnerability handler rebuilds a package rule for the alerting dep with `versioning` hardcoded to the datasource default (semver) and appends it after the repo rules, so it clobbers both the manager's `loose` and any rule we write. Under semver the dep ends up with skipReason `invalid-value` and no updates at all, so even the routine digest bump stops.

The GitHub advisory path builds its rule without a `versioning` key, so dropping `osvVulnerabilityAlerts` leaves security PRs working while the manager's versioning survives. The gomarkdown rule from #234 goes with it: it could never take effect.