### PR TITLE
chore(deps): bump podcasts to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/CallumKerson/Athenaeum
 
-go 1.24.0
+go 1.25
 
 toolchain go1.26.5
 
 require (
-	github.com/CallumKerson/podcasts v1.0.0
+	github.com/CallumKerson/podcasts/v2 v2.0.0
 	github.com/alfg/mp4 v0.0.0-20210728035756-55ea58c08aeb
 	github.com/gomarkdown/markdown v0.0.0-20260725000948-8435af3f5984
 	github.com/pelletier/go-toml/v2 v2.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/CallumKerson/podcasts v1.0.0 h1:nnmuguaJb3IAL6DdJAhol83lmfswzMrVgv2VS4BJFlk=
-github.com/CallumKerson/podcasts v1.0.0/go.mod h1:SGDAg6H7VevfPLGtEQ2y5HvA+5h2rJKiCkh+ygGeRhc=
+github.com/CallumKerson/podcasts/v2 v2.0.0 h1:iC8BwPpsV2LHXszEIAI9huiUlz4onDR7gpV8ZVOxog4=
+github.com/CallumKerson/podcasts/v2 v2.0.0/go.mod h1:WnxFp1dnxcisHy7nzg/IIS/brS80hUxz3J7oGILEHSA=
 github.com/alfg/mp4 v0.0.0-20210728035756-55ea58c08aeb h1:v8z8Yym2Z/NCYgXO/aFqmYDYa/d3uRyVMq1DjgMfzn4=
 github.com/alfg/mp4 v0.0.0-20210728035756-55ea58c08aeb/go.mod h1:RfuO8OqkqAcWXXkaS3MuymrBQJbKJWi04H/bs6vNvh0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CallumKerson/podcasts"
+	"github.com/CallumKerson/podcasts/v2"
 
 	"github.com/CallumKerson/Athenaeum/pkg/audiobooks"
 )


### PR DESCRIPTION
Upgrades `github.com/CallumKerson/podcasts` from v1.0.0 to [v2.0.0](https://github.com/CallumKerson/podcasts/releases/tag/v2.0.0).

## Why it's a three-line change

v2 is a breaking release — it removed the performance API, renamed the `Podcast` accessors and moved to the `/v2` import path. Athenaeum uses none of what changed:

| v2 change | Used by Athenaeum? |
|---|---|
| `Feed.StreamWrite`, `Feed.WriteWithOptions`, `Feed.XMLWithOptions`, `WriteOptions` removed | No — `internal/feed/feed.go:78` uses `Feed.Write` |
| `GetBufferPool` / `GetStringBuilderPool` removed | No |
| `Podcast.AddItemWithCapacity` removed | No — uses `AddItem` |
| `GetItemCount`/`GetItems`/`GetItemsSlice` renamed or removed | No — never called |

So the diff is the import path, the requirement, and the `go` directive.

## Feed output is unchanged

This matters because `internal/feed/testdata` is a parity guarantee for existing subscribers, and a `<guid>` change would make every subscriber re-download the whole library.

**The fixtures still match byte for byte.** Neither of v2's two output fixes can reach Athenaeum:

- `itunes:category` now sorts before `<item>` elements — Athenaeum renders no categories.
- Negative `Duration` values now marshal as `-1:30` instead of the malformed `-1:0-30` — durations come from `.m4b` files and are never negative.

## One side effect

The `go` directive moves `1.24.0` → `1.25`, because podcasts v2 requires 1.25. `toolchain` was already pinned to `go1.26.5`, so nothing about the build environment changes — but it does raise Athenaeum's own minimum Go. Flagging it since it wasn't strictly part of the ask; say the word if you'd rather I pin podcasts to something older instead.

## Verification

- `mise run test` — all packages pass, including the feed parity fixtures
- `mise run check-all` — clean
- `go mod tidy` leaves no trace of v1