### PR TITLE
test: cover the build command, feed metadata and atomic write failures

### DIFF
--- a/cmd/athenaeum/build_config_test.go
+++ b/cmd/athenaeum/build_config_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/CallumKerson/Athenaeum/pkg/audiobooks"
+)
+
+func TestLoadBuildConfigReadsTOML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), configName)
+	require.NoError(t, os.WriteFile(path, []byte(`
+Host = "https://books.example.com"
+
+[Media]
+Root = "/srv/audiobooks"
+
+[Site]
+Root = "/srv/www"
+
+[Podcast]
+Author = "Someone"
+Email = "someone@example.com"
+Language = "FR"
+Explicit = false
+
+[ThirdParty]
+NotifyOvercast = true
+
+[ExclusionsFromMainFeed]
+Genres = ["Erotica"]
+`), 0o600))
+
+	var out bytes.Buffer
+	cfg, err := LoadBuildConfig(path, &out)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://books.example.com", cfg.Host)
+	assert.Equal(t, "/srv/audiobooks", cfg.Media.Root)
+	assert.Equal(t, "/srv/www", cfg.Site.Root)
+	assert.Equal(t, "Someone", cfg.Podcast.Author)
+	assert.Equal(t, "FR", cfg.Podcast.Language)
+	assert.False(t, cfg.Podcast.Explicit)
+	assert.True(t, cfg.ThirdParty.NotifyOvercast)
+	assert.Equal(t, []string{"Erotica"}, cfg.ExclusionsFromMainFeed.Genres)
+	assert.Empty(t, out.String())
+}
+
+// A config file that sets nothing must not clear the defaults, since Explicit
+// and PreUnixEpoch default to true and TOML has no way to say "unset".
+func TestLoadBuildConfigKeepsDefaultsForAbsentKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), configName)
+	require.NoError(t, os.WriteFile(path, []byte("Host = \"https://books.example.com\"\n"), 0o600))
+
+	cfg, err := LoadBuildConfig(path, &bytes.Buffer{})
+	require.NoError(t, err)
+
+	assert.True(t, cfg.Podcast.Explicit)
+	assert.True(t, cfg.Podcast.PreUnixEpoch.Handle)
+	assert.Equal(t, "EN", cfg.Podcast.Language)
+}
+
+func TestLoadBuildConfigMissingFileUsesDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nothing-here.toml")
+
+	var out bytes.Buffer
+	cfg, err := LoadBuildConfig(path, &out)
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://localhost:8080", cfg.Host)
+	assert.True(t, cfg.Podcast.Explicit)
+	assert.Contains(t, out.String(), "No config file at")
+}
+
+func TestLoadBuildConfigInvalidTOML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), configName)
+	require.NoError(t, os.WriteFile(path, []byte("Host = \n"), 0o600))
+
+	_, err := LoadBuildConfig(path, &bytes.Buffer{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), path)
+}
+
+// The message exists so that the move from the server's YAML config to the XDG
+// TOML one does not look like the config silently vanished.
+func TestLoadBuildConfigNotesLegacyConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".athenaeum"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(home, legacyConfigPath), []byte("host: x\n"), 0o600))
+
+	var out bytes.Buffer
+	_, err := LoadBuildConfig(filepath.Join(t.TempDir(), "absent.toml"), &out)
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), ".athenaeum/config.yaml")
+}
+
+func TestLoadBuildConfigWithoutLegacyConfigSaysNothingExtra(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	var out bytes.Buffer
+	_, err := LoadBuildConfig(filepath.Join(t.TempDir(), "absent.toml"), &out)
+	require.NoError(t, err)
+
+	assert.NotContains(t, out.String(), "config.yaml")
+}
+
+// os.UserConfigDir returns ~/Library/Application Support on macOS and ignores
+// XDG_CONFIG_HOME entirely, which is why these paths are resolved by hand.
+func TestDefaultPathsPreferXDGVariables(t *testing.T) {
+	configHome, cacheHome := t.TempDir(), t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+
+	configPath, err := DefaultConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(configHome, appName, configName), configPath)
+
+	cachePath, err := DefaultCachePath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(cacheHome, appName, cacheName), cachePath)
+}
+
+func TestDefaultPathsFallBackToHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	configPath, err := DefaultConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".config", appName, configName), configPath)
+
+	cachePath, err := DefaultCachePath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".cache", appName, cacheName), cachePath)
+}
+
+func TestGetGenres(t *testing.T) {
+	genres, err := ExclusionsFromMainFeed{Genres: []string{"Erotica", "sci-fi"}}.GetGenres()
+
+	require.NoError(t, err)
+	assert.Equal(t, []audiobooks.Genre{audiobooks.Erotica, audiobooks.SciFi}, genres)
+}
+
+func TestGetGenresEmpty(t *testing.T) {
+	genres, err := ExclusionsFromMainFeed{}.GetGenres()
+
+	require.NoError(t, err)
+	assert.Empty(t, genres)
+}
+
+func TestGetGenresUnknownGenre(t *testing.T) {
+	_, err := ExclusionsFromMainFeed{Genres: []string{"Erotica", "spycraft"}}.GetGenres()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spycraft")
+}

--- a/cmd/athenaeum/build_test.go
+++ b/cmd/athenaeum/build_test.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/CallumKerson/Athenaeum/internal/site"
+)
+
+// mediaRoot is the pair of test audiobooks in the repository root.
+const mediaRoot = "../../testdata"
+
+// isolateEnv points the XDG variables at scratch directories so that a test can
+// never read — or write — the developer's real config and duration cache.
+func isolateEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+}
+
+func TestBuildCommandWritesSite(t *testing.T) {
+	isolateEnv(t)
+	out := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	cmd := NewRootCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"build",
+		"--media-root", mediaRoot,
+		"--out", out,
+		"--host", "https://books.example.com",
+		"--cache", filepath.Join(t.TempDir(), "m4b.json"),
+	})
+
+	require.NoError(t, cmd.ExecuteContext(context.Background()))
+
+	// The feed and the pages a subscriber and a browser respectively land on.
+	assert.FileExists(t, filepath.Join(out, "podcast", "feed.rss"))
+	assert.FileExists(t, filepath.Join(out, "index.html"))
+	assert.FileExists(t, filepath.Join(out, "books", "index.html"))
+	assert.FileExists(t, filepath.Join(out, site.MarkerName))
+
+	feed, err := os.ReadFile(filepath.Join(out, "podcast", "feed.rss"))
+	require.NoError(t, err)
+	assert.Contains(t, string(feed), "A Wizard of Earthsea")
+	// The host reaches the enclosure URLs, which are also the GUIDs.
+	assert.Contains(t, string(feed), "https://books.example.com/media/")
+
+	assert.Contains(t, stderr.String(), "scanned library")
+}
+
+// The whole point of the generator is that running it twice is a no-op, so that
+// unchanged files keep their mtimes and the web server keeps serving 304s.
+func TestBuildCommandIsIdempotent(t *testing.T) {
+	isolateEnv(t)
+	out := t.TempDir()
+	cachePath := filepath.Join(t.TempDir(), "m4b.json")
+
+	run := func() string {
+		var stderr bytes.Buffer
+		cmd := NewRootCommand()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&stderr)
+		cmd.SetArgs([]string{
+			"build", "--media-root", mediaRoot, "--out", out,
+			"--host", "https://books.example.com", "--cache", cachePath,
+		})
+		require.NoError(t, cmd.ExecuteContext(context.Background()))
+		return stderr.String()
+	}
+
+	run()
+	feedPath := filepath.Join(out, "podcast", "feed.rss")
+	first, err := os.Stat(feedPath)
+	require.NoError(t, err)
+
+	second := run()
+
+	after, err := os.Stat(feedPath)
+	require.NoError(t, err)
+	assert.Equal(t, first.ModTime(), after.ModTime(), "unchanged feed was rewritten")
+	assert.Contains(t, second, "written=0")
+	// The second run should have read every duration from the cache.
+	assert.Contains(t, second, "parsed=0")
+}
+
+func TestBuildCommandRejectsForeignOutputDirectory(t *testing.T) {
+	isolateEnv(t)
+	out := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(out, "important.txt"), []byte("mine"), 0o600))
+
+	cmd := NewRootCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"build", "--media-root", mediaRoot, "--out", out,
+		"--cache", filepath.Join(t.TempDir(), "m4b.json"),
+	})
+
+	err := cmd.ExecuteContext(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), site.MarkerName)
+	assert.FileExists(t, filepath.Join(out, "important.txt"))
+}
+
+func TestBuildCommandRejectsUnknownExcludedGenre(t *testing.T) {
+	isolateEnv(t)
+	configPath := filepath.Join(t.TempDir(), configName)
+	require.NoError(t, os.WriteFile(configPath, []byte(
+		"[ExclusionsFromMainFeed]\nGenres = [\"spycraft\"]\n"), 0o600))
+
+	cmd := NewRootCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"build", "--config", configPath,
+		"--media-root", mediaRoot, "--out", t.TempDir(),
+	})
+
+	err := cmd.ExecuteContext(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "spycraft")
+}
+
+func TestResolveConfigFlagsBeatFile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), configName)
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+Host = "https://from-file.example.com"
+
+[Media]
+Root = "/from/file/media"
+
+[Site]
+Root = "/from/file/site"
+`), 0o600))
+
+	cfg, err := resolveConfig(&buildFlags{
+		configPath: configPath,
+		mediaRoot:  "/from/flag/media",
+		siteRoot:   "/from/flag/site",
+		host:       "https://from-flag.example.com",
+	}, &bytes.Buffer{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/from/flag/media", cfg.Media.Root)
+	assert.Equal(t, "/from/flag/site", cfg.Site.Root)
+	assert.Equal(t, "https://from-flag.example.com", cfg.Host)
+}
+
+func TestResolveConfigKeepsFileValuesWhenFlagsAreEmpty(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), configName)
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+[Media]
+Root = "/from/file/media"
+
+[Site]
+Root = "/from/file/site"
+`), 0o600))
+
+	cfg, err := resolveConfig(&buildFlags{configPath: configPath}, &bytes.Buffer{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "/from/file/media", cfg.Media.Root)
+	assert.Equal(t, "/from/file/site", cfg.Site.Root)
+}
+
+func TestResolveConfigRequiresRoots(t *testing.T) {
+	absent := filepath.Join(t.TempDir(), "absent.toml")
+
+	_, err := resolveConfig(&buildFlags{configPath: absent}, &bytes.Buffer{})
+	require.ErrorIs(t, err, errNoMediaRoot)
+
+	_, err = resolveConfig(&buildFlags{configPath: absent, mediaRoot: "/media"}, &bytes.Buffer{})
+	require.ErrorIs(t, err, errNoSiteRoot)
+}
+
+func TestResolveConfigPropagatesLoadError(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), configName)
+	require.NoError(t, os.WriteFile(configPath, []byte("Host = \n"), 0o600))
+
+	_, err := resolveConfig(&buildFlags{configPath: configPath}, &bytes.Buffer{})
+
+	require.Error(t, err)
+}
+
+func TestScanLibraryUsesCacheOnSecondRun(t *testing.T) {
+	isolateEnv(t)
+	cachePath := filepath.Join(t.TempDir(), "m4b.json")
+	cfg := &BuildConfig{Media: Media{Root: mediaRoot}}
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+	books, cache, err := scanLibrary(cfg, &buildFlags{cachePath: cachePath}, logger)
+	require.NoError(t, err)
+	require.NotEmpty(t, books)
+	assert.Zero(t, cache.Hits)
+	assert.Positive(t, cache.Misses)
+
+	_, warm, err := scanLibrary(cfg, &buildFlags{cachePath: cachePath}, logger)
+	require.NoError(t, err)
+	assert.Equal(t, len(books), warm.Hits)
+	assert.Zero(t, warm.Misses)
+}
+
+// --no-cache must neither read nor write the cache file.
+func TestScanLibraryNoCacheLeavesCacheFileAlone(t *testing.T) {
+	isolateEnv(t)
+	cachePath := filepath.Join(t.TempDir(), "m4b.json")
+	cfg := &BuildConfig{Media: Media{Root: mediaRoot}}
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+	_, cache, err := scanLibrary(cfg, &buildFlags{cachePath: cachePath, noCache: true}, logger)
+
+	require.NoError(t, err)
+	assert.Zero(t, cache.Hits)
+	assert.NoFileExists(t, cachePath)
+}
+
+// A corrupt cache costs a re-read, never a failed build.
+func TestScanLibraryToleratesUnreadableCache(t *testing.T) {
+	isolateEnv(t)
+	cachePath := filepath.Join(t.TempDir(), "m4b.json")
+	require.NoError(t, os.WriteFile(cachePath, []byte("{not json"), 0o600))
+
+	var logged bytes.Buffer
+	books, cache, err := scanLibrary(
+		&BuildConfig{Media: Media{Root: mediaRoot}},
+		&buildFlags{cachePath: cachePath},
+		slog.New(slog.NewTextHandler(&logged, nil)),
+	)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, books)
+	assert.Positive(t, cache.Misses)
+	assert.Contains(t, logged.String(), "could not read cache")
+}
+
+func TestScanLibraryFallsBackToDefaultCachePath(t *testing.T) {
+	isolateEnv(t)
+
+	_, _, err := scanLibrary(
+		&BuildConfig{Media: Media{Root: mediaRoot}},
+		&buildFlags{},
+		slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+	)
+
+	require.NoError(t, err)
+	expected, err := DefaultCachePath()
+	require.NoError(t, err)
+	assert.FileExists(t, expected)
+}
+
+func TestScanLibraryMissingMediaRoot(t *testing.T) {
+	isolateEnv(t)
+
+	_, _, err := scanLibrary(
+		&BuildConfig{Media: Media{Root: filepath.Join(t.TempDir(), "absent")}},
+		&buildFlags{cachePath: filepath.Join(t.TempDir(), "m4b.json")},
+		slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+	)
+
+	require.Error(t, err)
+}
+
+func TestRendererForCarriesConfigThrough(t *testing.T) {
+	renderer := rendererFor(&BuildConfig{
+		Host: "https://books.example.com",
+		Podcast: Podcast{
+			Explicit:     true,
+			Language:     "FR",
+			Author:       "Someone",
+			Email:        "someone@example.com",
+			PreUnixEpoch: PreUnixEpoch{Handle: true},
+		},
+	})
+
+	assert.Equal(t, "https://books.example.com", renderer.Host)
+	assert.Equal(t, mediaPath, renderer.MediaPath)
+	assert.Equal(t, "https://books.example.com/static/itunes_image.jpg", renderer.ImageLink)
+	assert.Equal(t, "FR", renderer.Language)
+	assert.Equal(t, "Someone", renderer.Author)
+	assert.Equal(t, "someone@example.com", renderer.Email)
+	assert.True(t, renderer.Explicit)
+	assert.True(t, renderer.HandlePreUnixEpoch)
+}
+
+func TestBuildLoggerLevel(t *testing.T) {
+	var quiet, verbose bytes.Buffer
+
+	buildLogger(&quiet, false).Debug("hidden")
+	buildLogger(&verbose, true).Debug("shown")
+
+	assert.Empty(t, quiet.String())
+	assert.Contains(t, verbose.String(), "shown")
+}
+
+// notifyOvercast talks to a hard-coded endpoint, so the reachable case here is
+// the request never leaving: a cancelled context fails before any network use.
+func TestNotifyOvercastCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := notifyOvercast(ctx, "https://books.example.com")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestVersionCommand(t *testing.T) {
+	var out bytes.Buffer
+	cmd := NewRootCommand()
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"version"})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, out.String(), "version: ")
+	assert.Contains(t, out.String(), "commit:  ")
+	assert.Contains(t, out.String(), "built at:")
+}
+
+func TestRootCommandHasSubcommands(t *testing.T) {
+	subcommands := NewRootCommand().Commands()
+	names := make([]string, 0, len(subcommands))
+	for _, sub := range subcommands {
+		names = append(names, sub.Name())
+	}
+
+	assert.Contains(t, names, "build")
+	assert.Contains(t, names, "version")
+}

--- a/internal/feed/feed_test.go
+++ b/internal/feed/feed_test.go
@@ -6,12 +6,16 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/pelletier/go-toml/v2"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/CallumKerson/Athenaeum/internal/testing/testbooks"
 	"github.com/CallumKerson/Athenaeum/pkg/audiobooks"
+	"github.com/CallumKerson/Athenaeum/pkg/audiobooks/description"
 )
 
 // The golden files here are copies of the ones the server's podcast service was
@@ -170,4 +174,118 @@ func TestRenderWithoutReleaseDate(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, string(rendered), "<title>Undated</title>")
+}
+
+// The channel-level iTunes metadata is optional, so the golden feeds above are
+// rendered without any of it. These cover the branches that set it.
+func TestRenderSetsChannelMetadata(t *testing.T) {
+	renderer := &Renderer{
+		Host:      "http://www.example-podcast.com",
+		MediaPath: "/media/",
+		Author:    "Athenaeum",
+		Email:     "books@example.com",
+		Explicit:  true,
+		ImageLink: "http://www.example-podcast.com/static/itunes_image.jpg",
+		Language:  "EN",
+	}
+
+	rendered, err := renderer.Render(testbooks.Audiobooks, "Audiobooks", "Like movies in your mind!")
+
+	require.NoError(t, err)
+	feed := string(rendered)
+	assert.Contains(t, feed, "<itunes:author>Athenaeum</itunes:author>")
+	assert.Contains(t, feed, "<itunes:name>Athenaeum</itunes:name>")
+	assert.Contains(t, feed, "<itunes:email>books@example.com</itunes:email>")
+	assert.Contains(t, feed, "<itunes:explicit>yes</itunes:explicit>")
+	assert.Contains(t, feed, `<itunes:image href="http://www.example-podcast.com/static/itunes_image.jpg">`)
+	assert.Contains(t, feed, "<language>EN</language>")
+}
+
+// A Host that url.Parse rejects has to fail the build rather than produce a feed
+// full of broken enclosure URLs, which are also the GUIDs.
+func TestRenderRejectsUnparseableHost(t *testing.T) {
+	renderer := &Renderer{Host: "http://[::1", MediaPath: "/media/"}
+
+	_, err := renderer.Render(testbooks.Audiobooks, "Audiobooks", "Like movies in your mind!")
+
+	require.Error(t, err)
+}
+
+// Podcast clients disagree about negative timestamps, so a release date before
+// 1970 is clamped up to the epoch — plus the eight hour offset every pubDate gets.
+func TestPubDateClampsPreUnixEpochDates(t *testing.T) {
+	preEpoch := toml.LocalDate{Year: 1968, Month: 11, Day: 1}
+	book := audiobooks.Audiobook{Title: "A Wizard of Earthsea", ReleaseDate: &preEpoch}
+
+	clamping := &Renderer{HandlePreUnixEpoch: true}
+	assert.Equal(t, unixEpoch.Add(8*time.Hour), clamping.pubDate(&book))
+
+	passingThrough := &Renderer{}
+	assert.Equal(t, preEpoch.AsTime(time.UTC).Add(8*time.Hour), passingThrough.pubDate(&book))
+}
+
+func TestSummaryHTMLRepeatsTitleForSubtitledBook(t *testing.T) {
+	summary := summaryHTML(&audiobooks.Audiobook{
+		Title:    "What If?",
+		Subtitle: "Serious Scientific Answers to Absurd Hypothetical Questions",
+		Authors:  []string{"Randall Munroe"},
+	})
+
+	assert.Contains(t, summary, "<h1>What If?</h1>")
+	// Reproduces the original: the title, not the subtitle, is repeated.
+	assert.Contains(t, summary, "<h4>What If?</h4>")
+	assert.NotContains(t, summary, "Absurd Hypothetical")
+}
+
+func TestSummaryHTMLDescriptionFormats(t *testing.T) {
+	tests := []struct {
+		name   string
+		format description.Format
+		text   string
+		want   string
+	}{
+		{
+			name:   "markdown becomes HTML",
+			format: description.Markdown,
+			text:   "A *terrible* shadow.",
+			want:   "<em>terrible</em>",
+		},
+		{
+			name:   "HTML passes through",
+			format: description.HTML,
+			text:   "<p>A <em>terrible</em> shadow.</p>",
+			want:   "<p>A <em>terrible</em> shadow.</p>",
+		},
+		{
+			name:   "plain text becomes paragraphs",
+			format: description.Plain,
+			text:   "First line.\nSecond line.",
+			want:   "<p>First line.</p><p>Second line.</p>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			summary := summaryHTML(&audiobooks.Audiobook{
+				Title:       "A Wizard of Earthsea",
+				Authors:     []string{"Ursula K. Le Guin"},
+				Description: &description.Description{Text: test.text, Format: test.format},
+			})
+
+			assert.Contains(t, summary, test.want)
+		})
+	}
+}
+
+func TestSummaryHTMLIncludesSeriesAndNarrator(t *testing.T) {
+	summary := summaryHTML(&audiobooks.Audiobook{
+		Title:     "A Wizard of Earthsea",
+		Authors:   []string{"Ursula K. Le Guin"},
+		Narrators: []string{"Kobna Holdbrook-Smith"},
+		Series:    &audiobooks.Series{Title: "Earthsea", Sequence: decimal.NewFromInt(1)},
+	})
+
+	assert.Contains(t, summary, "<h2>By Ursula K. Le Guin</h2>")
+	assert.Contains(t, summary, "<h4>Earthsea Book 1</h4>")
+	assert.Contains(t, summary, "<h4>Narrated by Kobna Holdbrook-Smith</h4>")
 }

--- a/internal/fsutil/write_test.go
+++ b/internal/fsutil/write_test.go
@@ -70,3 +70,52 @@ func TestWriteIfChanged(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "second", string(contents))
 }
+
+func TestWriteAtomicParentIsNotADirectory(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("a file, not a directory"), 0o600))
+
+	err := WriteAtomic(filepath.Join(blocker, "nested", "file.txt"), []byte("hello"))
+
+	require.Error(t, err)
+}
+
+// The temp file lands beside its target, so a directory that cannot be written
+// to fails before anything is renamed into place.
+func TestWriteAtomicUnwritableDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	err := WriteAtomic(filepath.Join(dir, "file.txt"), []byte("hello"))
+
+	require.Error(t, err)
+	assert.NoFileExists(t, filepath.Join(dir, "file.txt"))
+}
+
+// A write that fails must not leave the previous contents replaced, nor leave a
+// half-written temp file behind for the sweep to trip over.
+func TestWriteAtomicFailureLeavesExistingFileIntact(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	require.NoError(t, WriteAtomic(path, []byte("original")))
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	require.Error(t, WriteAtomic(path, []byte("replacement")))
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(contents))
+
+	require.NoError(t, os.Chmod(dir, 0o700))
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "a temp file was left behind")
+}


### PR DESCRIPTION
## Coverage

| Package | Before | After |
|---|---|---|
| `cmd/athenaeum` | 0.0% | **86.4%** |
| `internal/feed` | 76.3% | **91.5%** |
| `internal/fsutil` | 68.4% | **78.9%** |
| `internal/scan` | 82.8% | 82.8% |
| `internal/site` | 91.5% | 91.5% |
| `pkg/audiobooks` | 59.3% | 100% *(from #242, not this PR)* |
| `pkg/audiobooks/description` | 100% | 100% |
| `internal/testing/testbooks` | 0.0% | 0.0% *(see below)* |

## `cmd/athenaeum` — 0% → 86.4%

The package had no tests at all, despite holding the flag-over-config layering and the hand-rolled XDG path resolution — the latter exists precisely because `os.UserConfigDir` ignores `XDG_CONFIG_HOME` on macOS, which is the kind of thing that only breaks on someone else's machine.

Covered: `LoadBuildConfig` (valid TOML, absent file, malformed TOML, the legacy-config notice, and that absent keys keep their defaults rather than zeroing `Explicit`/`PreUnixEpoch`), `xdgPath` and both default paths under XDG-set and HOME-fallback conditions, `resolveConfig` precedence and both missing-root errors, `scanLibrary` (cold, warm, `--no-cache`, corrupt cache, default path fallback), `rendererFor`, `buildLogger`, `GetGenres`, and the version/root command wiring.

Three end-to-end tests drive the real cobra command over the repo's `testdata/` library: one asserts the feed and pages are written with the host in the enclosure URLs, one asserts a second run rewrites nothing (`written=0`, `parsed=0`, feed mtime unchanged — the ETag-stability invariant), and one asserts a foreign output directory is refused with its contents intact.

**Every test that touches the default paths points `HOME`, `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` at scratch directories.** Without that, `LoadBuildConfig`'s fallback reads the developer's real `~/.config/athenaeum/athenaeum.toml` and `scanLibrary` writes their real duration cache — so the suite would behave differently per machine and mutate state outside the test.

## `internal/feed` — 76.3% → 91.5%

The golden parity feeds are all rendered with no channel-level iTunes metadata, so `Author`/`Owner`/`Explicit`/`Image` were never set; likewise the markdown description branch and the pre-Unix-epoch clamp were never taken. Adds direct tests for each, plus one asserting a `Host` that `url.Parse` rejects fails the render rather than emitting broken enclosure URLs — which are also the GUIDs.

## `internal/fsutil` — 68.4% → 78.9%, short of the bar

Covers the two reachable `WriteAtomic` failures (parent path is a file; directory not writable), and adds a test that a failed write leaves the previous contents intact with no temp file behind for the sweep to trip over.

The remaining three uncovered branches are `tmp.Write`, `tmp.Close` and `os.Chmod` failing on an already-open descriptor. There is no portable way to provoke those from a test — reaching them means injecting a filesystem seam into a 50-line helper purely to satisfy a number, which seemed the worse trade. Happy to add it if you'd rather have the bar met.

## `internal/testing/testbooks` stays at 0%

It reports 0% because coverage is attributed per-package and it has no tests of its own, but it is a test fixture that `internal/feed`'s tests exercise fully — measured with `-coverpkg=./...` it is at 100%. Writing tests for it would be testing test code.

## Checks

`mise run check-all` is clean (including the `errcheck`/`errorlint` from #241) and `go test -race ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)